### PR TITLE
[FEAT]: 테스트 토큰 발급 기능 추가, 토큰 발급시 Authentication을 사용하지 않도록 수정

### DIFF
--- a/src/main/java/com/goat/server/auth/application/AuthService.java
+++ b/src/main/java/com/goat/server/auth/application/AuthService.java
@@ -1,11 +1,18 @@
 package com.goat.server.auth.application;
 
 import com.goat.server.auth.dto.response.ReIssueSuccessResponse;
+import com.goat.server.auth.dto.response.SignUpSuccessResponse;
+import com.goat.server.global.domain.JwtUserDetails;
 import com.goat.server.global.util.JwtTokenProvider;
-import com.goat.server.global.util.filter.UserAuthentication;
+import com.goat.server.mypage.domain.User;
+import com.goat.server.mypage.domain.type.Role;
+import com.goat.server.mypage.exception.UserNotFoundException;
+import com.goat.server.mypage.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import static com.goat.server.mypage.exception.errorcode.MypageErrorCode.USER_NOT_FOUND;
 
 @Slf4j
 @Service
@@ -13,13 +20,28 @@ import org.springframework.stereotype.Service;
 public class AuthService {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
 
     public ReIssueSuccessResponse reIssueToken(String refreshToken) {
 
-        Long userId = jwtTokenProvider.getUserIdFromJwt(refreshToken);
+        Long userId = jwtTokenProvider.getJwtUserDetails(refreshToken).userId();
 
-        UserAuthentication userAuthentication = new UserAuthentication(userId, null, null);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
 
-        return ReIssueSuccessResponse.From(jwtTokenProvider.generateToken(userAuthentication));
+        return ReIssueSuccessResponse
+                .from(jwtTokenProvider.generateToken(JwtUserDetails
+                        .of(userId, user.getRole())
+                        )
+                );
+    }
+
+    public SignUpSuccessResponse getTestToken() {
+
+        return SignUpSuccessResponse
+                .from(jwtTokenProvider.generateToken(JwtUserDetails
+                        .of(1L, Role.USER)
+                        )
+                );
     }
 }

--- a/src/main/java/com/goat/server/auth/application/KakaoSocialService.java
+++ b/src/main/java/com/goat/server/auth/application/KakaoSocialService.java
@@ -1,8 +1,8 @@
 package com.goat.server.auth.application;
 
+import com.goat.server.global.domain.JwtUserDetails;
 import com.goat.server.global.exception.CustomFeignException;
 import com.goat.server.global.util.JwtTokenProvider;
-import com.goat.server.global.util.filter.UserAuthentication;
 import com.goat.server.mypage.domain.User;
 import com.goat.server.mypage.repository.UserRepository;
 import com.goat.server.mypage.application.UserService;
@@ -12,11 +12,8 @@ import feign.FeignException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Service;
 import com.goat.server.auth.dto.response.KakaoUserResponse;
-
-import java.util.Collections;
 
 import static com.goat.server.auth.exception.errorcode.AuthErrorCode.FEIGN_FAILED;
 
@@ -38,12 +35,9 @@ public class KakaoSocialService {
 
         User user = findOrCreateUser(userResponse);
 
-        UserAuthentication userAuthentication =
-                new UserAuthentication(user.getUserId(),
-                null,
-                Collections.singletonList(new SimpleGrantedAuthority(user.getRole().name())));
+        JwtUserDetails jwtUserDetails = new JwtUserDetails(user.getUserId(), user.getRole());
 
-        return SignUpSuccessResponse.From(jwtTokenProvider.generateToken(userAuthentication));
+        return SignUpSuccessResponse.from(jwtTokenProvider.generateToken(jwtUserDetails));
 
     }
 

--- a/src/main/java/com/goat/server/auth/dto/response/ReIssueSuccessResponse.java
+++ b/src/main/java/com/goat/server/auth/dto/response/ReIssueSuccessResponse.java
@@ -8,7 +8,7 @@ public record ReIssueSuccessResponse(
         String accessToken,
         String refreshToken
 ) {
-    public static ReIssueSuccessResponse From(Tokens token) {
+    public static ReIssueSuccessResponse from(Tokens token) {
         return ReIssueSuccessResponse.builder()
                 .accessToken(token.accessToken())
                 .refreshToken(token.refreshToken())

--- a/src/main/java/com/goat/server/auth/dto/response/SignUpSuccessResponse.java
+++ b/src/main/java/com/goat/server/auth/dto/response/SignUpSuccessResponse.java
@@ -8,7 +8,7 @@ public record SignUpSuccessResponse(
         String accessToken,
         String refreshToken
 ) {
-    public static SignUpSuccessResponse From(Tokens token) {
+    public static SignUpSuccessResponse from(Tokens token) {
         return SignUpSuccessResponse.builder()
                 .accessToken(token.accessToken())
                 .refreshToken(token.refreshToken())

--- a/src/main/java/com/goat/server/auth/presentation/AuthController.java
+++ b/src/main/java/com/goat/server/auth/presentation/AuthController.java
@@ -50,4 +50,17 @@ public class AuthController {
                 .status(HttpStatus.OK)
                 .body(ResponseTemplate.from(response));
     }
+
+    @Operation(summary = "테스트용 토큰발급", description = "테스트용 토큰발급")
+    @GetMapping("/testToken")
+    public ResponseEntity<ResponseTemplate<Object>> testToken() {
+
+        log.info("[AuthController.testToken]");
+
+        SignUpSuccessResponse response = authService.getTestToken();
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ResponseTemplate.from(response));
+    }
 }

--- a/src/main/java/com/goat/server/global/domain/JwtUserDetails.java
+++ b/src/main/java/com/goat/server/global/domain/JwtUserDetails.java
@@ -1,0 +1,14 @@
+package com.goat.server.global.domain;
+
+import com.goat.server.mypage.domain.type.Role;
+import lombok.Builder;
+
+@Builder
+public record JwtUserDetails(
+        Long userId,
+        Role role
+) {
+    public static JwtUserDetails of(Long userId, Role role) {
+        return new JwtUserDetails(userId, role);
+    }
+}

--- a/src/main/java/com/goat/server/global/util/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/goat/server/global/util/filter/JwtAuthenticationFilter.java
@@ -31,9 +31,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         final String token = getJwtFromRequest(request);
 
         if (token != null && jwtTokenProvider.validateToken(token) == VALID_JWT) {
-            Long userId = jwtTokenProvider.getUserIdFromJwt(token);
 
-            UserAuthentication authentication = new UserAuthentication(userId.toString(), null, null);
+            UserAuthentication authentication = UserAuthentication.from(jwtTokenProvider.getJwtUserDetails(token));
 
             authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 

--- a/src/main/java/com/goat/server/global/util/filter/UserAuthentication.java
+++ b/src/main/java/com/goat/server/global/util/filter/UserAuthentication.java
@@ -1,5 +1,6 @@
 package com.goat.server.global.util.filter;
 
+import com.goat.server.global.domain.JwtUserDetails;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 
@@ -9,5 +10,9 @@ public class UserAuthentication extends UsernamePasswordAuthenticationToken {
 
     public UserAuthentication(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
         super(principal, credentials, authorities);
+    }
+
+    public static UserAuthentication from(JwtUserDetails jwtUserDetails) {
+        return new UserAuthentication(jwtUserDetails.userId(), null, jwtUserDetails.role().getAuthority());
     }
 }

--- a/src/main/java/com/goat/server/mypage/domain/type/Role.java
+++ b/src/main/java/com/goat/server/mypage/domain/type/Role.java
@@ -1,5 +1,15 @@
 package com.goat.server.mypage.domain.type;
 
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collection;
+import java.util.Collections;
+
 public enum Role {
-    ADMIN, USER, GUEST
+    ADMIN, USER, GUEST;
+
+    public Collection<? extends GrantedAuthority> getAuthority() {
+        return Collections.singletonList(new SimpleGrantedAuthority(this.name()));
+    }
 }

--- a/src/test/java/com/goat/server/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/goat/server/auth/application/AuthServiceTest.java
@@ -1,15 +1,20 @@
 package com.goat.server.auth.application;
 
 import com.goat.server.auth.dto.response.ReIssueSuccessResponse;
+import com.goat.server.global.domain.JwtUserDetails;
 import com.goat.server.global.domain.type.Tokens;
 import com.goat.server.global.util.JwtTokenProvider;
-import com.goat.server.global.util.filter.UserAuthentication;
+import static com.goat.server.mypage.fixture.UserFixture.USER_USER;
+import com.goat.server.mypage.domain.type.Role;
+import com.goat.server.mypage.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
@@ -23,12 +28,16 @@ class AuthServiceTest {
     @Mock
     private JwtTokenProvider jwtTokenProvider;
 
+    @Mock
+    private UserRepository userRepository;
+
     @Test
     @DisplayName("토큰 재발급 테스트")
     void reIssueToken() {
         // given
-        given(jwtTokenProvider.getUserIdFromJwt("refreshToken")).willReturn(1L);
-        given(jwtTokenProvider.generateToken(new UserAuthentication(1L,null, null)))
+        given(userRepository.findById(1L)).willReturn(Optional.ofNullable(USER_USER));
+        given(jwtTokenProvider.getJwtUserDetails("refreshToken")).willReturn(new JwtUserDetails(1L, Role.USER));
+        given(jwtTokenProvider.generateToken(new JwtUserDetails(1L, Role.USER)))
                 .willReturn(new Tokens("reIssuedAccessToken", "reIssuedRefreshToken"));
 
         // when

--- a/src/test/java/com/goat/server/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/goat/server/auth/presentation/AuthControllerTest.java
@@ -40,7 +40,7 @@ class AuthControllerTest extends CommonControllerTest {
         final String kakaoAccessToken = "thisIsmockAccessToken";
 
         given(kakaoSocialService.socialLogin(kakaoAccessToken))
-                .willReturn(SignUpSuccessResponse.From(Tokens.builder()
+                .willReturn(SignUpSuccessResponse.from(Tokens.builder()
                         .accessToken("accessToken")
                         .refreshToken("refreshToken")
                         .build()));
@@ -64,7 +64,7 @@ class AuthControllerTest extends CommonControllerTest {
         final String refreshToken = "thisIsRefreshToken";
 
         given(authService.reIssueToken(refreshToken))
-                .willReturn(ReIssueSuccessResponse.From(Tokens.builder()
+                .willReturn(ReIssueSuccessResponse.from(Tokens.builder()
                         .accessToken("accessToken")
                         .refreshToken("refreshToken")
                         .build()));

--- a/src/test/java/com/goat/server/global/CommonControllerTest.java
+++ b/src/test/java/com/goat/server/global/CommonControllerTest.java
@@ -3,6 +3,7 @@ package com.goat.server.global;
 
 import com.goat.server.global.util.JwtTokenProvider;
 import com.goat.server.global.util.filter.UserAuthentication;
+import com.goat.server.mypage.domain.type.Role;
 import jakarta.servlet.ServletException;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -21,7 +22,7 @@ public class CommonControllerTest {
 
     @BeforeEach
     public void setUp() throws ServletException, IOException {
-        UserAuthentication userAuthentication = new UserAuthentication("testUser", null, null);
+        UserAuthentication userAuthentication = new UserAuthentication(123, null, Role.USER.getAuthority());
         SecurityContextHolder.getContext().setAuthentication(userAuthentication);
     }
 }


### PR DESCRIPTION
## 관련 이슈

- Resolves #

## 개요

> 테스트 토큰 발급 기능 추가, 토큰 발급시 Authentication을 사용하지 않도록 수정

## 작업 사항

- GET /goat/auth/testToken 경로의 테스트토큰 발급기능 추가
- 토큰 발급시 security에 대한 의존성을 줄이기 위해 Authentication을 사용하지 않도록 수정

## Check List
- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 작업한 사람 모두를 Assign
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인
