### PR TITLE
[UPDATE] userId를 통해 테스트 토큰을 발급 받도록 수정, 일부 클래스의 위치 변경

### DIFF
--- a/src/main/java/com/goat/server/auth/application/AuthService.java
+++ b/src/main/java/com/goat/server/auth/application/AuthService.java
@@ -4,9 +4,9 @@ import com.goat.server.auth.dto.response.ReIssueSuccessResponse;
 import com.goat.server.auth.dto.response.SignUpSuccessResponse;
 import com.goat.server.global.domain.JwtUserDetails;
 import com.goat.server.global.util.JwtTokenProvider;
-import com.goat.server.mypage.domain.User;
 import com.goat.server.mypage.domain.type.Role;
 import com.goat.server.mypage.exception.UserNotFoundException;
+import com.goat.server.mypage.repository.JwtUserDetailProjection;
 import com.goat.server.mypage.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,22 +26,23 @@ public class AuthService {
 
         Long userId = jwtTokenProvider.getJwtUserDetails(refreshToken).userId();
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
-
         return ReIssueSuccessResponse
-                .from(jwtTokenProvider.generateToken(JwtUserDetails
-                        .of(userId, user.getRole())
-                        )
-                );
+                .from(jwtTokenProvider.generateToken(getJwtUserDetails(userId)));
     }
 
-    public SignUpSuccessResponse getTestToken() {
+    public SignUpSuccessResponse getTestToken(Long userId) {
 
         return SignUpSuccessResponse
-                .from(jwtTokenProvider.generateToken(JwtUserDetails
-                        .of(1L, Role.USER)
-                        )
-                );
+                .from(jwtTokenProvider.generateToken(getJwtUserDetails(userId)));
+    }
+
+    public JwtUserDetails getJwtUserDetails(Long userId) {
+        JwtUserDetailProjection jwtUserDetailProjection = userRepository.findJwtUserDetailsById(userId);
+
+        if (jwtUserDetailProjection == null) {
+            throw new UserNotFoundException(USER_NOT_FOUND);
+        }
+
+        return JwtUserDetails.of(jwtUserDetailProjection.getUserId(), Role.valueOf(jwtUserDetailProjection.getRole()));
     }
 }

--- a/src/main/java/com/goat/server/auth/dto/response/KakaoAccount.java
+++ b/src/main/java/com/goat/server/auth/dto/response/KakaoAccount.java
@@ -1,4 +1,4 @@
-package com.goat.server.auth.domain;
+package com.goat.server.auth.dto.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;

--- a/src/main/java/com/goat/server/auth/dto/response/KakaoUserProfile.java
+++ b/src/main/java/com/goat/server/auth/dto/response/KakaoUserProfile.java
@@ -1,4 +1,4 @@
-package com.goat.server.auth.domain;
+package com.goat.server.auth.dto.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;

--- a/src/main/java/com/goat/server/auth/dto/response/KakaoUserResponse.java
+++ b/src/main/java/com/goat/server/auth/dto/response/KakaoUserResponse.java
@@ -2,7 +2,6 @@ package com.goat.server.auth.dto.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.goat.server.auth.domain.KakaoAccount;
 import lombok.Builder;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)

--- a/src/main/java/com/goat/server/auth/presentation/AuthController.java
+++ b/src/main/java/com/goat/server/auth/presentation/AuthController.java
@@ -39,7 +39,7 @@ public class AuthController {
     }
 
     @Operation(summary = "토큰 재발급", description = "토큰 재발급")
-    @GetMapping("/refreshToken")
+    @GetMapping("/refresh-token")
     public ResponseEntity<ResponseTemplate<Object>> reIssueToken(@RequestHeader(value = HttpHeaders.AUTHORIZATION) String refreshToken) {
 
         log.info("[AuthController.reIssueToken] refreshToken: {}", refreshToken);
@@ -52,12 +52,12 @@ public class AuthController {
     }
 
     @Operation(summary = "테스트용 토큰발급", description = "테스트용 토큰발급")
-    @GetMapping("/testToken")
-    public ResponseEntity<ResponseTemplate<Object>> testToken() {
+    @GetMapping("/test-token")
+    public ResponseEntity<ResponseTemplate<Object>> testToken(@RequestParam Long userId) {
 
         log.info("[AuthController.testToken]");
 
-        SignUpSuccessResponse response = authService.getTestToken();
+        SignUpSuccessResponse response = authService.getTestToken(userId);
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/src/main/java/com/goat/server/mypage/repository/JwtUserDetailProjection.java
+++ b/src/main/java/com/goat/server/mypage/repository/JwtUserDetailProjection.java
@@ -1,0 +1,6 @@
+package com.goat.server.mypage.repository;
+
+public interface JwtUserDetailProjection {
+    Long getUserId();
+    String getRole();
+}

--- a/src/main/java/com/goat/server/mypage/repository/UserRepository.java
+++ b/src/main/java/com/goat/server/mypage/repository/UserRepository.java
@@ -2,9 +2,13 @@ package com.goat.server.mypage.repository;
 
 import com.goat.server.mypage.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     User findBySocialId(String string);
+
+    @Query("SELECT u.userId as userId, u.role as role FROM User u WHERE u.userId = :userId")
+    JwtUserDetailProjection findJwtUserDetailsById(Long userId);
 }

--- a/src/test/java/com/goat/server/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/goat/server/auth/application/AuthServiceTest.java
@@ -6,6 +6,7 @@ import com.goat.server.global.domain.type.Tokens;
 import com.goat.server.global.util.JwtTokenProvider;
 import static com.goat.server.mypage.fixture.UserFixture.USER_USER;
 import com.goat.server.mypage.domain.type.Role;
+import com.goat.server.mypage.repository.JwtUserDetailProjection;
 import com.goat.server.mypage.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,7 +36,17 @@ class AuthServiceTest {
     @DisplayName("토큰 재발급 테스트")
     void reIssueToken() {
         // given
-        given(userRepository.findById(1L)).willReturn(Optional.ofNullable(USER_USER));
+        given(userRepository.findJwtUserDetailsById(1L)).willReturn(new JwtUserDetailProjection() {
+            @Override
+            public Long getUserId() {
+                return 1L;
+            }
+
+            @Override
+            public String getRole() {
+                return Role.USER.toString();
+            }
+        });
         given(jwtTokenProvider.getJwtUserDetails("refreshToken")).willReturn(new JwtUserDetails(1L, Role.USER));
         given(jwtTokenProvider.generateToken(new JwtUserDetails(1L, Role.USER)))
                 .willReturn(new Tokens("reIssuedAccessToken", "reIssuedRefreshToken"));

--- a/src/test/java/com/goat/server/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/goat/server/auth/presentation/AuthControllerTest.java
@@ -70,7 +70,7 @@ class AuthControllerTest extends CommonControllerTest {
                         .build()));
 
         //when
-        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/goat/auth/refreshToken")
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/goat/auth/refresh-token")
                 .header("Authorization", refreshToken));
 
         //then


### PR DESCRIPTION
## 관련 이슈

- Resolves #

## 개요

> 테스트 토큰을 발급 로직 수정, 일부 클래스의 위치 변경, 일부 api의 end-point 네이밍 변경

## 작업 사항

- userId를 쿼리파라미터로 받아, 테스트 토큰을 발급 받도록 수정
- KakaoAccount, KakaoUserProfile의 위치를 domain 에서 dto.response로 변경
- 토큰 재발급 api와 테스트 토큰 발급 api 의 end-point 네이밍 수정

## Check List
- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 작업한 사람 모두를 Assign
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인
