### PR TITLE
[FEAT] 회원탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/goat/server/auth/application/AuthService.java
+++ b/src/main/java/com/goat/server/auth/application/AuthService.java
@@ -2,15 +2,22 @@ package com.goat.server.auth.application;
 
 import com.goat.server.auth.dto.OnBoardingRequest;
 import com.goat.server.auth.dto.response.ReIssueSuccessResponse;
+import com.goat.server.directory.domain.Directory;
+import com.goat.server.directory.repository.DirectoryRepository;
+import com.goat.server.global.application.S3Uploader;
 import com.goat.server.global.util.jwt.JwtUserDetails;
 import com.goat.server.global.util.jwt.JwtTokenProvider;
 import com.goat.server.mypage.domain.User;
 import com.goat.server.mypage.exception.UserNotFoundException;
 import com.goat.server.mypage.repository.UserRepository;
+import com.goat.server.review.domain.Review;
+import com.goat.server.review.repository.ReviewRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 import static com.goat.server.mypage.exception.errorcode.MypageErrorCode.USER_NOT_FOUND;
 
@@ -21,6 +28,9 @@ public class AuthService {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
+    private final S3Uploader s3Uploader;
+    private final ReviewRepository reviewRepository;
+    private final DirectoryRepository directoryRepository;
 
     public ReIssueSuccessResponse reIssueToken(String refreshToken) {
 
@@ -55,5 +65,28 @@ public class AuthService {
         }
 
         userRepository.save(user);
+    }
+
+    public void deregister(Long userId) {
+
+        log.info("[AuthService.deregister]");
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
+
+        s3Uploader.deleteImage(user.getImageInfo());
+
+        List<Review> reviews = reviewRepository.findAllByUser(user);
+        if(!reviews.isEmpty()) {
+            reviews.forEach(review -> s3Uploader.deleteImage(review.getImageInfo()));
+            reviewRepository.deleteAll(reviews);
+        }
+
+        List<Directory> directories = directoryRepository.findAllByUser(user);
+        if(!directories.isEmpty()) {
+            directoryRepository.deleteAll(directories);
+        }
+
+        userRepository.deleteById(userId);
     }
 }

--- a/src/main/java/com/goat/server/auth/application/AuthService.java
+++ b/src/main/java/com/goat/server/auth/application/AuthService.java
@@ -67,25 +67,14 @@ public class AuthService {
         userRepository.save(user);
     }
 
-    public void deregister(Long userId) {
+    public void withdraw(Long userId) {
 
-        log.info("[AuthService.deregister]");
+        log.info("[AuthService.withdraw]");
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
 
         s3Uploader.deleteImage(user.getImageInfo());
-
-        List<Review> reviews = reviewRepository.findAllByUser(user);
-        if(!reviews.isEmpty()) {
-            reviews.forEach(review -> s3Uploader.deleteImage(review.getImageInfo()));
-            reviewRepository.deleteAll(reviews);
-        }
-
-        List<Directory> directories = directoryRepository.findAllByUser(user);
-        if(!directories.isEmpty()) {
-            directoryRepository.deleteAll(directories);
-        }
 
         userRepository.deleteById(userId);
     }

--- a/src/main/java/com/goat/server/auth/presentation/AuthController.java
+++ b/src/main/java/com/goat/server/auth/presentation/AuthController.java
@@ -41,7 +41,7 @@ public class AuthController {
     }
 
     @Operation(summary = "회원탈퇴", description = "회원탈퇴")
-    @GetMapping("/deregister")
+    @DeleteMapping("/deregister")
     public ResponseEntity<ResponseTemplate<Object>> deregister(@AuthenticationPrincipal Long userId) {
 
         log.info("[AuthController.deregister]");

--- a/src/main/java/com/goat/server/auth/presentation/AuthController.java
+++ b/src/main/java/com/goat/server/auth/presentation/AuthController.java
@@ -46,7 +46,7 @@ public class AuthController {
 
         log.info("[AuthController.deregister]");
 
-        authService.deregister(userId);
+        authService.withdraw(userId);
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/src/main/java/com/goat/server/auth/presentation/AuthController.java
+++ b/src/main/java/com/goat/server/auth/presentation/AuthController.java
@@ -40,6 +40,19 @@ public class AuthController {
                 .body(ResponseTemplate.from(response));
     }
 
+    @Operation(summary = "회원탈퇴", description = "회원탈퇴")
+    @GetMapping("/deregister")
+    public ResponseEntity<ResponseTemplate<Object>> deregister(@AuthenticationPrincipal Long userId) {
+
+        log.info("[AuthController.deregister]");
+
+        authService.deregister(userId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ResponseTemplate.from(ResponseTemplate.EMPTY_RESPONSE));
+    }
+
     @Operation(summary = "토큰 재발급", description = "토큰 재발급")
     @GetMapping("/refresh-token")
     public ResponseEntity<ResponseTemplate<Object>> reIssueToken(@RequestHeader(value = HttpHeaders.AUTHORIZATION) String refreshToken) {

--- a/src/main/java/com/goat/server/directory/repository/DirectoryRepository.java
+++ b/src/main/java/com/goat/server/directory/repository/DirectoryRepository.java
@@ -1,7 +1,11 @@
 package com.goat.server.directory.repository;
 
 import com.goat.server.directory.domain.Directory;
+
+import java.util.List;
 import java.util.Optional;
+
+import com.goat.server.mypage.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -14,4 +18,6 @@ public interface DirectoryRepository extends JpaRepository<Directory, Long>, Dir
 
     @Query("SELECT d FROM Directory d WHERE d.user.userId = :userId AND d.title = 'storage_directory'")
     Optional<Directory> findStorageDirectoryByUser(Long userId);
+
+    List<Directory> findAllByUser(User user);
 }

--- a/src/main/java/com/goat/server/mypage/domain/User.java
+++ b/src/main/java/com/goat/server/mypage/domain/User.java
@@ -1,5 +1,6 @@
 package com.goat.server.mypage.domain;
 
+import com.goat.server.directory.domain.Directory;
 import com.goat.server.global.domain.BaseTimeEntity;
 import com.goat.server.global.domain.ImageInfo;
 import com.goat.server.global.domain.type.OauthProvider;
@@ -8,6 +9,8 @@ import com.goat.server.mypage.domain.type.Role;
 import com.goat.server.mypage.domain.type.School;
 
 import com.goat.server.mypage.dto.request.MypageDetailsRequest;
+import com.goat.server.notification.domain.Notification;
+import com.goat.server.notification.domain.NotificationSetting;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -65,9 +68,19 @@ public class User extends BaseTimeEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.PERSIST, orphanRemoval = true)
     private List<Major> majorList = new ArrayList<>();
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Directory> directories = new ArrayList<>();
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private NotificationSetting notificationSetting;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Notification> notification;
+
     @Builder
     public User(School school, Grade grade, ImageInfo imageInfo, String nickname, Role role, String socialId,
-                String email, OauthProvider provider, String goal, String fcmToken, List<Major> majorList) {
+                String email, OauthProvider provider, String goal, String fcmToken, List<Major> majorList,
+                List<Directory> directories, NotificationSetting notificationSetting, List<Notification> notification) {
         this.school = school;
         this.grade = grade;
         this.imageInfo = imageInfo;
@@ -79,6 +92,9 @@ public class User extends BaseTimeEntity {
         this.goal = goal;
         this.fcmToken = fcmToken;
         this.majorList = majorList;
+        this.directories = directories;
+        this.notificationSetting = notificationSetting;
+        this.notification = notification;
     }
 
     //마이페이지 목표 업데이트

--- a/src/main/java/com/goat/server/review/repository/ReviewRepository.java
+++ b/src/main/java/com/goat/server/review/repository/ReviewRepository.java
@@ -1,5 +1,6 @@
 package com.goat.server.review.repository;
 
+import com.goat.server.mypage.domain.User;
 import com.goat.server.review.domain.Review;
 
 import java.util.List;
@@ -32,4 +33,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRep
     Long sumReviewCntByUser(Long userId);
 
     List<Review> findAll();
+
+    List<Review> findAllByUser(User user);
 }

--- a/src/test/java/com/goat/server/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/goat/server/auth/application/AuthServiceTest.java
@@ -6,7 +6,6 @@ import com.goat.server.directory.domain.Directory;
 import com.goat.server.directory.fixture.DirectoryFixture;
 import com.goat.server.directory.repository.DirectoryRepository;
 import com.goat.server.global.application.S3Uploader;
-import com.goat.server.global.domain.ImageInfo;
 import com.goat.server.global.util.jwt.JwtUserDetails;
 import com.goat.server.global.util.jwt.Tokens;
 import com.goat.server.global.util.jwt.JwtTokenProvider;
@@ -86,50 +85,15 @@ class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("회원탈퇴 테스트_리뷰와_폴더가_없는_경우")
-    void deregister() {
+    @DisplayName("회원탈퇴 테스트")
+    void withdraw() {
         // given
-        given(userRepository.findById(2L)).willReturn(Optional.of(USER_USER));
+        given(userRepository.findById(USER_USER.getUserId())).willReturn(Optional.of(USER_USER));
 
         // when
-        authService.deregister(2L);
+        authService.withdraw(USER_USER.getUserId());
 
         // then
-        verify(reviewRepository).findAllByUser(USER_USER);
-
-        verify(directoryRepository).findAllByUser(USER_USER);
-
-        verify(userRepository).deleteById(2L);
-        verify(s3Uploader).deleteImage(USER_USER.getImageInfo());
-
-        verifyNoMoreInteractions(reviewRepository, directoryRepository);
+        verify(userRepository).deleteById(USER_USER.getUserId());
     }
-
-    @Test
-    @DisplayName("회원탈퇴 테스트_리뷰와_폴더가_있는_경우")
-    void deregisterWithReviewsAndDirectories() {
-        // given
-        List<Review> reviews = List.of(ReviewFixture.DUMMY_REVIEW3);
-        List<Directory> directories = List.of(DirectoryFixture.PARENT_DIRECTORY1, DirectoryFixture.TRASH_DIRECTORY);
-
-        given(userRepository.findById(2L)).willReturn(Optional.of(USER_USER));
-        given(reviewRepository.findAllByUser(USER_USER)).willReturn(reviews);
-        given(directoryRepository.findAllByUser(USER_USER)).willReturn(directories);
-
-        // when
-        authService.deregister(2L);
-
-        // then
-        verify(reviewRepository).findAllByUser(USER_USER);
-        verify(reviewRepository).deleteAll(reviews);
-        verify(s3Uploader).deleteImage(ReviewFixture.DUMMY_REVIEW3.getImageInfo());
-
-        verify(directoryRepository).findAllByUser(USER_USER);
-        verify(directoryRepository).deleteAll(directories);
-
-
-        verify(userRepository).deleteById(2L);
-        verify(s3Uploader).deleteImage(USER_USER.getImageInfo());
-    }
-
 }

--- a/src/test/java/com/goat/server/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/goat/server/auth/presentation/AuthControllerTest.java
@@ -107,7 +107,7 @@ class AuthControllerTest extends CommonControllerTest {
     @DisplayName("회원탈퇴 테스트")
     void deregister() throws Exception {
         //when
-        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/goat/auth/deregister")
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.delete("/goat/auth/deregister")
                 .header("Authorization", "accessToken"));
 
         //then

--- a/src/test/java/com/goat/server/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/goat/server/auth/presentation/AuthControllerTest.java
@@ -7,6 +7,7 @@ import com.goat.server.auth.dto.OnBoardingRequest;
 import com.goat.server.auth.dto.response.ReIssueSuccessResponse;
 import com.goat.server.auth.dto.response.SignUpSuccessResponse;
 import com.goat.server.global.CommonControllerTest;
+import com.goat.server.global.application.S3Uploader;
 import com.goat.server.global.util.jwt.Tokens;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -96,6 +97,18 @@ class AuthControllerTest extends CommonControllerTest {
         ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.patch("/goat/auth/info")
                 .content(objectMapper.writeValueAsString(new OnBoardingRequest("nickname", "안녕하세요!", "fcmToken")))
                 .contentType("application/json"));
+
+        //then
+        resultActions
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("회원탈퇴 테스트")
+    void deregister() throws Exception {
+        //when
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/goat/auth/deregister")
+                .header("Authorization", "accessToken"));
 
         //then
         resultActions

--- a/src/test/java/com/goat/server/mypage/fixture/UserFixture.java
+++ b/src/test/java/com/goat/server/mypage/fixture/UserFixture.java
@@ -1,5 +1,6 @@
 package com.goat.server.mypage.fixture;
 
+import com.goat.server.global.domain.ImageInfo;
 import com.goat.server.global.domain.type.OauthProvider;
 import com.goat.server.mypage.domain.User;
 import com.goat.server.mypage.domain.type.Grade;
@@ -24,6 +25,7 @@ public class UserFixture {
             .goal("user go home")
             .provider(OauthProvider.KAKAO)
             .fcmToken("c5z1BZ-J4UIEv58an4DPTK:APA91bGBItmR0XevTVL4wUJqOTW4vESdyhpkdrNu1scBDPV-rBAc31GsASTvK3hSSGrIGs9X9zijLdJqpe9dZbHI2oTdQHyZLNlhxFCJYb08L99vJMWPYsoaJQux88SKKQWoXYRuzVZf")
+            .imageInfo(new ImageInfo("imageFileName", "imageFolderName", "imageUrl"))
             .build();
 
     public static final User USER_ADMIN = User.builder()

--- a/src/test/java/com/goat/server/review/fixture/ReviewFixture.java
+++ b/src/test/java/com/goat/server/review/fixture/ReviewFixture.java
@@ -2,6 +2,7 @@ package com.goat.server.review.fixture;
 
 import com.goat.server.directory.fixture.DirectoryFixture;
 import com.goat.server.global.domain.ImageInfo;
+import com.goat.server.mypage.fixture.UserFixture;
 import com.goat.server.review.domain.Review;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -18,9 +19,16 @@ public class ReviewFixture {
             .title("imageTitle2")
             .imageInfo(new ImageInfo("review2", "goat", "http://goat.goat.com2"))
             .build();
+    public static Review DUMMY_REVIEW3 = Review.builder()
+            .directory(DirectoryFixture.PARENT_DIRECTORY1)
+            .title("imageTitle2")
+            .imageInfo(new ImageInfo("review3", "goat", "http://goat.goat.com3"))
+            .user(UserFixture.USER_USER)
+            .build();
 
     static {
         ReflectionTestUtils.setField(DUMMY_REVIEW1, "id", 1L);
         ReflectionTestUtils.setField(DUMMY_REVIEW2, "id", 2L);
+        ReflectionTestUtils.setField(DUMMY_REVIEW3, "id", 3L);
     }
 }


### PR DESCRIPTION
## 관련 이슈

- Resolves #34 

## 개요

> 회원탈퇴 기능 구현: 회원 즉시 삭제

## 작업 사항

- DB에서 회원 정보 삭제, 회원이 등록한 directory와 review 삭제, S3에서 회원이 등록한 이미지 삭제

## Check List
- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 작업한 사람 모두를 Assign
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인
