### PR TITLE
[HOTFIX] 정렬 키워드가 없을 때 잘못 동작하는 로직 수정

### DIFF
--- a/src/main/java/com/goat/server/directory/repository/DirectoryRepositoryImpl.java
+++ b/src/main/java/com/goat/server/directory/repository/DirectoryRepositoryImpl.java
@@ -37,7 +37,7 @@ public class DirectoryRepositoryImpl implements DirectoryRepositoryCustom {
 
     //search가 null이면 parentDirectoryId로 검색, 아니면 search로 검색 - search 존재 -> 전체 검색
     private BooleanExpression isSearchExpression(Long parentDirectoryId, String search) {
-        if (StringUtils.hasLength(search)) {
+        if (!StringUtils.hasLength(search)) {
             return parentDirectoryFindExpression(parentDirectoryId);
         } else {
             return directory.title.contains(search);

--- a/src/main/java/com/goat/server/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/goat/server/review/repository/ReviewRepositoryImpl.java
@@ -37,7 +37,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 
     //search가 null이면 parentDirectoryId로 검색, 아니면 search로 검색 - search 존재 -> 전체 검색
     private BooleanExpression searchExpression(Long parentDirectoryId, String search) {
-        if (StringUtils.hasLength(search)) {
+        if (!StringUtils.hasLength(search)) {
             return review.directory.id.eq(parentDirectoryId);
         } else {
             return review.title.contains(search);


### PR DESCRIPTION
## 관련 이슈


## 개요

> 정렬 키워드가 없을 때 잘못 동작하는 로직 수정

## 작업 사항

- 정렬 키워드가 없을 때 잘못 동작하는 로직 수정

## Check List
- [ ] PR 제목을 커밋 규칙에 맞게 작성
- [ ] PR에 해당되는 Issue를 연결 완료
- [ ] 작업한 사람 모두를 Assign
- [ ] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [ ] `main` 브랜치의 최신 상태를 반영하고 있는지 확인
