### PR TITLE
[FEAT] 놓친 복습 api 구현

### DIFF
--- a/src/main/java/com/goat/server/notification/application/NotificationService.java
+++ b/src/main/java/com/goat/server/notification/application/NotificationService.java
@@ -1,6 +1,7 @@
 package com.goat.server.notification.application;
 
 import com.goat.server.global.exception.AccessDeniedException;
+import com.goat.server.mypage.application.UserService;
 import com.goat.server.mypage.domain.User;
 import com.goat.server.mypage.exception.UserNotFoundException;
 import com.goat.server.mypage.repository.UserRepository;
@@ -24,7 +25,7 @@ import static com.goat.server.mypage.exception.errorcode.MypageErrorCode.USER_NO
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
-    private final UserRepository userRepository;
+    private final UserService userService;
 
     @Transactional
     public void saveNotification(Notification notification) {
@@ -38,8 +39,7 @@ public class NotificationService {
 
             log.info("[NotificationService.getNotifications]");
 
-            User user = userRepository.findById(userId)
-                    .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
+            User user = userService.findUser(userId);
 
             List<Notification> notifications = notificationRepository.findAllByUser(user);
 
@@ -65,5 +65,14 @@ public class NotificationService {
         notification.read();
 
         notificationRepository.save(notification);
+    }
+
+    public List<Notification> findAllByUserId(Long userId) {
+
+            log.info("[NotificationService.findAllByUserId]");
+
+            User user = userService.findUser(userId);
+
+            return notificationRepository.findAllByUser(user);
     }
 }

--- a/src/main/java/com/goat/server/notification/application/NotificationService.java
+++ b/src/main/java/com/goat/server/notification/application/NotificationService.java
@@ -66,10 +66,8 @@ public class NotificationService {
 
     public List<Notification> getUnreadNotifications(Long userId) {
 
-            log.info("[NotificationService.getNotReadNotifications]");
+            log.info("[NotificationService.getNotReadNotifications] userId: {}", userId);
 
-            User user = userService.findUser(userId);
-
-            return notificationRepository.findAllByUserAndIsRead(user, false);
+            return notificationRepository.findAllByUserIdAndIsRead(userId, false);
     }
 }

--- a/src/main/java/com/goat/server/notification/application/NotificationService.java
+++ b/src/main/java/com/goat/server/notification/application/NotificationService.java
@@ -3,8 +3,6 @@ package com.goat.server.notification.application;
 import com.goat.server.global.exception.AccessDeniedException;
 import com.goat.server.mypage.application.UserService;
 import com.goat.server.mypage.domain.User;
-import com.goat.server.mypage.exception.UserNotFoundException;
-import com.goat.server.mypage.repository.UserRepository;
 import com.goat.server.notification.domain.Notification;
 import com.goat.server.notification.dto.response.NotificationResponse;
 import com.goat.server.notification.repository.NotificationRepository;
@@ -16,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static com.goat.server.global.exception.errorcode.GlobalErrorCode.ACCESS_DENIED;
-import static com.goat.server.mypage.exception.errorcode.MypageErrorCode.USER_NOT_FOUND;
 
 @Slf4j
 @Service
@@ -67,12 +64,12 @@ public class NotificationService {
         notificationRepository.save(notification);
     }
 
-    public List<Notification> findAllByUserId(Long userId) {
+    public List<Notification> getUnreadNotifications(Long userId) {
 
-            log.info("[NotificationService.findAllByUserId]");
+            log.info("[NotificationService.getNotReadNotifications]");
 
             User user = userService.findUser(userId);
 
-            return notificationRepository.findAllByUser(user);
+            return notificationRepository.findAllByUserAndIsRead(user, false);
     }
 }

--- a/src/main/java/com/goat/server/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/goat/server/notification/repository/NotificationRepository.java
@@ -3,6 +3,7 @@ package com.goat.server.notification.repository;
 import com.goat.server.mypage.domain.User;
 import com.goat.server.notification.domain.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
@@ -10,5 +11,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     List<Notification> findAllByUser(User user);
 
-    List<Notification> findAllByUserAndIsRead(User user, Boolean isRead);
+    @Query("SELECT n FROM Notification n JOIN FETCH n.review WHERE n.user.userId = :userId AND n.isRead = :isRead")
+    List<Notification> findAllByUserIdAndIsRead(Long userId, Boolean isRead);
 }

--- a/src/main/java/com/goat/server/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/goat/server/notification/repository/NotificationRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     List<Notification> findAllByUser(User user);
+
+    List<Notification> findAllByUserAndIsRead(User user, Boolean isRead);
 }

--- a/src/main/java/com/goat/server/review/application/ReviewService.java
+++ b/src/main/java/com/goat/server/review/application/ReviewService.java
@@ -323,9 +323,9 @@ public class ReviewService {
      */
     public MissedReviewResponse getMissedReview(Long userId) {
 
-        List<Notification> notifications = notificationService.findAllByUserId(userId);
+        List<Notification> unreadNotifications = notificationService.getUnreadNotifications(userId);
 
-        List<ReviewSimpleResponse> missedReviews = notifications.stream()
+        List<ReviewSimpleResponse> missedReviews = unreadNotifications.stream()
                 .map(Notification::getReview)
                 .map(ReviewSimpleResponse::from)
                 .toList();

--- a/src/main/java/com/goat/server/review/application/ReviewService.java
+++ b/src/main/java/com/goat/server/review/application/ReviewService.java
@@ -107,7 +107,7 @@ public class ReviewService {
         }
         reviewRepository.save(review);
 
-        if(review.getIsAutoRepeat() || review.getIsRepeatable() || !review.getReviewDates().isEmpty()) {
+        if(review.getIsRepeatable()) {
             registerNotification(review);
         }
     }
@@ -123,6 +123,7 @@ public class ReviewService {
             } catch (SchedulerException e) {
                 throw new RuntimeException(e);
             }
+            return;
         }
 
         for (ReviewDate date : review.getReviewDates()) {

--- a/src/main/java/com/goat/server/review/application/ReviewService.java
+++ b/src/main/java/com/goat/server/review/application/ReviewService.java
@@ -12,6 +12,8 @@ import com.goat.server.mypage.domain.User;
 import com.goat.server.mypage.exception.UserNotFoundException;
 import com.goat.server.mypage.exception.errorcode.MypageErrorCode;
 import com.goat.server.mypage.repository.UserRepository;
+import com.goat.server.notification.application.NotificationService;
+import com.goat.server.notification.domain.Notification;
 import com.goat.server.review.domain.Review;
 import com.goat.server.review.domain.ReviewDate;
 import com.goat.server.review.domain.UnViewedReview;
@@ -52,6 +54,7 @@ public class ReviewService {
     private final DirectoryRepository directoryRepository;
     private final S3Uploader s3Uploader;
     private final UserService userService;
+    private final NotificationService notificationService;
 
     private final SchedulerConfiguration schedulerConfiguration;
 
@@ -313,5 +316,20 @@ public class ReviewService {
      */
     public Long calculateReviewCount(Long userId) {
         return reviewRepository.sumReviewCntByUser(userId);
+    }
+
+    /**
+     * 놓친 복습 불러오기
+     */
+    public MissedReviewResponse getMissedReview(Long userId) {
+
+        List<Notification> notifications = notificationService.findAllByUserId(userId);
+
+        List<ReviewSimpleResponse> missedReviews = notifications.stream()
+                .map(Notification::getReview)
+                .map(ReviewSimpleResponse::from)
+                .toList();
+
+        return MissedReviewResponse.from(missedReviews);
     }
 }

--- a/src/main/java/com/goat/server/review/dto/response/MissedReviewResponse.java
+++ b/src/main/java/com/goat/server/review/dto/response/MissedReviewResponse.java
@@ -1,0 +1,14 @@
+package com.goat.server.review.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record MissedReviewResponse(
+        List<ReviewSimpleResponse> reviewSimpleResponses
+) {
+    public static MissedReviewResponse from(List<ReviewSimpleResponse> reviewSimpleResponseList) {
+        return new MissedReviewResponse(reviewSimpleResponseList);
+    }
+}

--- a/src/main/java/com/goat/server/review/presentation/ReviewController.java
+++ b/src/main/java/com/goat/server/review/presentation/ReviewController.java
@@ -172,4 +172,16 @@ public class ReviewController {
                 .status(HttpStatus.OK)
                 .body(ResponseTemplate.from(response));
     }
+
+    @Operation(summary = "놓친 복습 조회", description = "확인하지 않은 push 알림의 복습 조회")
+    @GetMapping("/missed-review")
+    public ResponseEntity<ResponseTemplate<Object>> getMissedReview(
+            @AuthenticationPrincipal Long userId) {
+
+        MissedReviewResponse response = reviewService.getMissedReview(userId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ResponseTemplate.from(response));
+    }
 }

--- a/src/test/java/com/goat/server/notification/fixture/NotificationFixture.java
+++ b/src/test/java/com/goat/server/notification/fixture/NotificationFixture.java
@@ -1,0 +1,30 @@
+package com.goat.server.notification.fixture;
+
+import com.goat.server.mypage.fixture.UserFixture;
+import com.goat.server.notification.domain.Notification;
+import com.goat.server.review.fixture.ReviewFixture;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class NotificationFixture {
+
+    public static final Notification DUMMY_NOTIFICATION1 = Notification.builder()
+            .user(UserFixture.USER_USER)
+            .review(ReviewFixture.DUMMY_REVIEW2)
+            .build();
+
+    public static final Notification DUMMY_NOTIFICATION2 = Notification.builder()
+            .user(UserFixture.USER_USER)
+            .review(ReviewFixture.DUMMY_REVIEW1)
+            .build();
+
+    public static final Notification DUMMY_NOTIFICATION3 = Notification.builder()
+            .user(UserFixture.USER_USER)
+            .review(ReviewFixture.DUMMY_REVIEW3)
+            .build();
+
+    static {
+        ReflectionTestUtils.setField(DUMMY_NOTIFICATION1, "noti_id", 1L);
+        ReflectionTestUtils.setField(DUMMY_NOTIFICATION2, "noti_id", 2L);
+        ReflectionTestUtils.setField(DUMMY_NOTIFICATION3, "noti_id", 3L);
+    }
+}

--- a/src/test/java/com/goat/server/review/application/ReviewServiceTest.java
+++ b/src/test/java/com/goat/server/review/application/ReviewServiceTest.java
@@ -29,7 +29,7 @@ public class ReviewServiceTest {
     @DisplayName("놓친 복습 조회 테스트")
     void getMissedReviewTest() {
         //given
-        given(notificationService.findAllByUserId(USER_USER.getUserId())).willReturn(List.of(DUMMY_NOTIFICATION1, DUMMY_NOTIFICATION2, DUMMY_NOTIFICATION3));
+        given(notificationService.getUnreadNotifications(USER_USER.getUserId())).willReturn(List.of(DUMMY_NOTIFICATION1, DUMMY_NOTIFICATION2, DUMMY_NOTIFICATION3));
 
         //when
         MissedReviewResponse response = reviewService.getMissedReview(USER_USER.getUserId());

--- a/src/test/java/com/goat/server/review/application/ReviewServiceTest.java
+++ b/src/test/java/com/goat/server/review/application/ReviewServiceTest.java
@@ -1,0 +1,40 @@
+package com.goat.server.review.application;
+
+import com.goat.server.notification.application.NotificationService;
+import com.goat.server.review.dto.response.MissedReviewResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static com.goat.server.mypage.fixture.UserFixture.USER_USER;
+import static com.goat.server.notification.fixture.NotificationFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class ReviewServiceTest {
+
+    @InjectMocks
+    private ReviewService reviewService;
+
+    @Mock
+    private NotificationService notificationService;
+
+    @Test
+    @DisplayName("놓친 복습 조회 테스트")
+    void getMissedReviewTest() {
+        //given
+        given(notificationService.findAllByUserId(USER_USER.getUserId())).willReturn(List.of(DUMMY_NOTIFICATION1, DUMMY_NOTIFICATION2, DUMMY_NOTIFICATION3));
+
+        //when
+        MissedReviewResponse response = reviewService.getMissedReview(USER_USER.getUserId());
+
+        //then
+        assertThat(response.reviewSimpleResponses()).hasSize(3);
+    }
+}

--- a/src/test/java/com/goat/server/review/presentation/ReviewControllerTest.java
+++ b/src/test/java/com/goat/server/review/presentation/ReviewControllerTest.java
@@ -1,0 +1,43 @@
+package com.goat.server.review.presentation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goat.server.global.CommonControllerTest;
+import com.goat.server.review.application.ReviewService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ReviewController.class)
+public class ReviewControllerTest extends CommonControllerTest {
+
+    @MockBean
+    private ReviewService reviewService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("놓친 복습 조회 테스트")
+    void getMissedReviewTest() throws Exception {
+
+        //when
+        ResultActions resultActions =
+                mockMvc.perform(get("/goat/missed-review"))
+                        .andDo(print());
+
+        //then
+        resultActions
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- Resolves #45 

## 개요

> 놓친 복습 api 구현

## 작업 사항

- 복습 등록시, 알림 등록 여부를 확인하는 로직 수정
- 놓친 복습 조회 api 구현
- 놓친 복습 조회 테스트 코드 작성

## Check List
- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 작업한 사람 모두를 Assign
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인
