### PR TITLE
[FEAT] 일반 회원가입 추가 (소셜 로그인 x)

### DIFF
--- a/src/main/java/com/goat/server/auth/application/AuthService.java
+++ b/src/main/java/com/goat/server/auth/application/AuthService.java
@@ -2,11 +2,13 @@ package com.goat.server.auth.application;
 
 import com.goat.server.auth.dto.request.OnBoardingRequest;
 import com.goat.server.auth.dto.response.ReIssueSuccessResponse;
+import com.goat.server.auth.dto.response.SignUpSuccessResponse;
 import com.goat.server.auth.dto.response.UserInfoResponse;
 import com.goat.server.global.application.S3Uploader;
 import com.goat.server.global.util.jwt.JwtUserDetails;
 import com.goat.server.global.util.jwt.JwtTokenProvider;
 import com.goat.server.mypage.domain.User;
+import com.goat.server.mypage.domain.type.Role;
 import com.goat.server.mypage.exception.UserNotFoundException;
 import com.goat.server.mypage.repository.UserRepository;
 import com.goat.server.review.repository.ReviewRepository;
@@ -73,5 +75,22 @@ public class AuthService {
         s3Uploader.deleteImage(user.getImageInfo());
 
         userRepository.deleteById(userId);
+    }
+
+    /**
+     * 소셜을 거치지 않은 일반 회원가입
+     */
+    public SignUpSuccessResponse signUp() {
+
+            log.info("[AuthService.signUp]");
+
+            User user = User.builder()
+                    .nickname("temporaryUser")
+                    .role(Role.GUEST)
+                    .build();
+
+            userRepository.save(user);
+
+            return SignUpSuccessResponse.of(jwtTokenProvider.generateToken(getJwtUserDetails(user.getUserId())), user, 0L);
     }
 }

--- a/src/main/java/com/goat/server/auth/presentation/AuthController.java
+++ b/src/main/java/com/goat/server/auth/presentation/AuthController.java
@@ -42,6 +42,22 @@ public class AuthController {
 
     }
 
+    /**
+     * 일반 회원 가입
+     */
+    @Operation(summary = "소셜 로그인 없는 회원가입", description = "일반 회원가입")
+    @GetMapping("/signup")
+    public ResponseEntity<ResponseTemplate<Object>> signUp() {
+
+        log.info("[AuthController.signUp]");
+
+        SignUpSuccessResponse response = authService.signUp();
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ResponseTemplate.from(response));
+    }
+
     @Operation(summary = "회원탈퇴", description = "회원탈퇴")
     @DeleteMapping("/withdraw")
     public ResponseEntity<ResponseTemplate<Object>> withdraw(@AuthenticationPrincipal Long userId) {

--- a/src/main/java/com/goat/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/goat/server/global/config/SecurityConfig.java
@@ -36,7 +36,8 @@ public class SecurityConfig {
                 "/goat/auth/login/**",
                 "/goat/auth/test-token",
                 "/goat/global/health-check",
-                "/actuator/**");
+                "/actuator/**",
+                "/goat/auth/signup");
     }
 
     @Bean

--- a/src/main/java/com/goat/server/mypage/application/UserService.java
+++ b/src/main/java/com/goat/server/mypage/application/UserService.java
@@ -40,6 +40,7 @@ public class UserService {
         User user = User.builder()
                 .socialId(userResponse.getId().toString())
                 .nickname(userResponse.getNickname())
+                .provider(userResponse.getOAuthProvider())
                 .role(Role.GUEST)
                 .build();
 

--- a/src/test/java/com/goat/server/auth/application/OAuthLoginServiceTest.java
+++ b/src/test/java/com/goat/server/auth/application/OAuthLoginServiceTest.java
@@ -3,6 +3,7 @@ package com.goat.server.auth.application;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.goat.server.auth.domain.type.OAuthProvider;
 import com.goat.server.directory.repository.DirectoryRepository;
 import com.goat.server.mypage.repository.UserRepository;
 import com.goat.server.notification.application.FcmServiceImpl;
@@ -95,6 +96,7 @@ class OAuthLoginServiceTest {
 
         //then
         assertNotNull(userRepository.findBySocialId(String.valueOf(1231241)));
+        assertThat(userRepository.findBySocialId(String.valueOf(1231241)).get().getProvider()).isEqualTo(OAuthProvider.KAKAO);
         assertThat(directoryRepository.findTrashDirectoryByUser(1L).get().getTitle()).isEqualTo("trash_directory");
         assertThat(directoryRepository.findStorageDirectoryByUser(1L).get().getTitle()).isEqualTo("storage_directory");
     }
@@ -131,6 +133,7 @@ class OAuthLoginServiceTest {
 
         //then
         assertNotNull(userRepository.findBySocialId("1203443"));
+        assertThat(userRepository.findBySocialId("1203443").get().getProvider()).isEqualTo(OAuthProvider.NAVER);
     }
 
 }


### PR DESCRIPTION
## 관련 이슈

- Resolves #

## 개요

> 소셜 간편 회원가입을 통하지 않은 일반 회원가입 추가

## 작업 사항

- 일반 회원가입 api 추가
- 소셜 회원가입시, OAuthProvider가 저장되지 않던 문제 수정

## Check List
- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 작업한 사람 모두를 Assign
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인
