### PR TITLE
[FIX] 일반 회원가입시 쓰레기통, 복습창고, 알림설정이 생성되지 않던 문제 수정

### DIFF
--- a/src/main/java/com/goat/server/auth/application/AuthService.java
+++ b/src/main/java/com/goat/server/auth/application/AuthService.java
@@ -84,11 +84,9 @@ public class AuthService {
      */
     public SignUpSuccessResponse signUp() {
 
-            log.info("[AuthService.signUp]");
-
             User user = userService.createUser();
 
-            userRepository.save(user);
+            log.info("[AuthService.signUp] userId: {}", user.getUserId());
 
             return SignUpSuccessResponse.of(jwtTokenProvider.generateToken(getJwtUserDetails(user.getUserId())), user, 0L);
     }

--- a/src/main/java/com/goat/server/auth/application/AuthService.java
+++ b/src/main/java/com/goat/server/auth/application/AuthService.java
@@ -7,6 +7,7 @@ import com.goat.server.auth.dto.response.UserInfoResponse;
 import com.goat.server.global.application.S3Uploader;
 import com.goat.server.global.util.jwt.JwtUserDetails;
 import com.goat.server.global.util.jwt.JwtTokenProvider;
+import com.goat.server.mypage.application.UserService;
 import com.goat.server.mypage.domain.User;
 import com.goat.server.mypage.domain.type.Role;
 import com.goat.server.mypage.exception.UserNotFoundException;
@@ -25,6 +26,7 @@ import static com.goat.server.mypage.exception.errorcode.MypageErrorCode.USER_NO
 public class AuthService {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final UserService userService;
     private final UserRepository userRepository;
     private final S3Uploader s3Uploader;
 
@@ -84,10 +86,7 @@ public class AuthService {
 
             log.info("[AuthService.signUp]");
 
-            User user = User.builder()
-                    .nickname("temporaryUser")
-                    .role(Role.GUEST)
-                    .build();
+            User user = userService.createUser();
 
             userRepository.save(user);
 

--- a/src/main/java/com/goat/server/mypage/application/UserService.java
+++ b/src/main/java/com/goat/server/mypage/application/UserService.java
@@ -33,7 +33,7 @@ public class UserService {
     private final ReviewRepository reviewRepository;
 
     /**
-     * 유저 회원가입
+     * 소셜 유저 회원가입
      */
     @Transactional
     public User createUser(final OAuthInfoResponse userResponse) {
@@ -74,6 +74,45 @@ public class UserService {
     public User findUser(final Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException(MypageErrorCode.USER_NOT_FOUND));
+    }
+
+    /**
+     * 일반 회원 가입
+     */
+    @Transactional
+    public User createUser() {
+        User user = User.builder()
+                .socialId(null)
+                .nickname("temporalUser")
+                .provider(null)
+                .role(Role.GUEST)
+                .build();
+
+        Directory trashDirectory = Directory.builder()
+                .user(user)
+                .title("trash_directory")
+                .depth(1L)
+                .build();
+
+        Directory storageDirectory = Directory.builder()
+                .user(user)
+                .title("storage_directory")
+                .depth(1L)
+                .build();
+
+        NotificationSetting notificationSetting = NotificationSetting.builder()
+                .user(user)
+                .isCommentNoti(false)
+                .isPostNoti(false)
+                .isReviewNoti(false)
+                .build();
+
+
+        notificationSettingRepository.save(notificationSetting);
+        directoryRepository.save(trashDirectory);
+        directoryRepository.save(storageDirectory);
+
+        return userRepository.save(user);
     }
 
     /**

--- a/src/main/java/com/goat/server/mypage/application/UserService.java
+++ b/src/main/java/com/goat/server/mypage/application/UserService.java
@@ -82,9 +82,7 @@ public class UserService {
     @Transactional
     public User createUser() {
         User user = User.builder()
-                .socialId(null)
                 .nickname("temporalUser")
-                .provider(null)
                 .role(Role.GUEST)
                 .build();
 

--- a/src/main/java/com/goat/server/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/goat/server/notification/dto/response/NotificationResponse.java
@@ -3,6 +3,8 @@ package com.goat.server.notification.dto.response;
 import com.goat.server.notification.domain.Notification;
 import lombok.Builder;
 
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 @Builder
@@ -14,15 +16,39 @@ public record NotificationResponse(
             Long notificationId,
             Long reviewId,
             String reviewBody,
+            String whenItPushed,
             Boolean isRead
     ){
         public static NotificationComponentResponse from(Notification notification) {
+
+            String whenItPushed = calculateWhenItPushed(notification);
+
             return NotificationComponentResponse.builder()
                     .notificationId(notification.getNoti_id())
                     .reviewId(notification.getReview().getId())
                     .reviewBody(notification.getContent())
+                    .whenItPushed(whenItPushed)
                     .isRead(notification.getIsRead())
                     .build();
+        }
+
+        private static String calculateWhenItPushed(Notification notification) {
+            LocalDate currentDate = LocalDate.now();
+            LocalDate createdDate = notification.getCreatedDate().toLocalDate();
+            long daysBetween = ChronoUnit.DAYS.between(createdDate, currentDate);
+            long hoursBetween = ChronoUnit.HOURS.between(createdDate, currentDate);
+
+            String whenItPushed = null;
+            if (daysBetween == 0) {
+                if(hoursBetween == 0) {
+                    whenItPushed = "방금 전";
+                } else {
+                    whenItPushed = hoursBetween + "시간 전";
+                }
+            } else {
+                whenItPushed = daysBetween + "일 전";
+            }
+            return whenItPushed;
         }
     }
 
@@ -31,4 +57,6 @@ public record NotificationResponse(
                 .notifications(notifications)
                 .build();
     }
+
+
 }


### PR DESCRIPTION
## 관련 이슈

- Resolves #

## 개요

> 1. 일반 회원가입시 쓰레기통, 복습창고, 알림설정이 생성되지 않던 문제 수정
> 2. 알림 응답에 해당 푸시가 언제 발행됐는지에 대한 정보 추가

## 작업 사항

- 일반 회원가입시에도 쓰레기통, 복습창고, 알림설정을 생성하도록 수정
- 알림 응답에 해당 푸시가 언제 발행됐는지에 대한 정보 추가

## Check List
- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 작업한 사람 모두를 Assign
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인
