### PR TITLE
[FIX] 알림 푸시 시점이 제대로 계산되지 않던 문제 수정

### DIFF
--- a/src/main/java/com/goat/server/global/config/SchedulerConfiguration.java
+++ b/src/main/java/com/goat/server/global/config/SchedulerConfiguration.java
@@ -105,7 +105,7 @@ public class SchedulerConfiguration implements WebMvcConfigurer {
         dataMap.put("reviewId", review.getId());
         dataMap.put("pushType", pushType.name());
 
-        String content = review.getUser().getNickname() + "님! 복습할 시간이에요" + review.getDirectory().getTitle() + "의 " + review.getTitle() + "을 복습해보세요!";
+        String content = review.getUser().getNickname() + "님, 복습할 시간이에요! " + review.getDirectory().getTitle() + "의 '" + review.getTitle() + "'을 지금 복습해 보세요!";
         dataMap.put("content", content);
 
         String notificationIdentity = "fcmSendJob" + review.getId() + "-" + notificationTime.toString();

--- a/src/main/java/com/goat/server/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/goat/server/notification/dto/response/NotificationResponse.java
@@ -4,6 +4,7 @@ import com.goat.server.notification.domain.Notification;
 import lombok.Builder;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
@@ -33,12 +34,13 @@ public record NotificationResponse(
         }
 
         private static String calculateWhenItPushed(Notification notification) {
-            LocalDate currentDate = LocalDate.now();
-            LocalDate createdDate = notification.getCreatedDate().toLocalDate();
-            long daysBetween = ChronoUnit.DAYS.between(createdDate, currentDate);
-            long hoursBetween = ChronoUnit.HOURS.between(createdDate, currentDate);
+            LocalDateTime currentDateTime = LocalDateTime.now();
+            LocalDateTime createdDateTime = notification.getCreatedDate();
+            long hoursBetween = ChronoUnit.HOURS.between(createdDateTime, currentDateTime);
+            long daysBetween = ChronoUnit.DAYS.between(createdDateTime.toLocalDate(), currentDateTime.toLocalDate());
 
             String whenItPushed = null;
+
             if (daysBetween == 0) {
                 if(hoursBetween == 0) {
                     whenItPushed = "방금 전";


### PR DESCRIPTION
## 관련 이슈

- Resolves #

## 개요

> 알림 응답시, 해당 푸시 알림이 언제 발행됐는지 계산하는 로직 수정, 알림 메시지 형식 수정

## 작업 사항

- 푸시 알림이 언제 발행됐는지 계산하는 로직 수정
- 알림 메시지 형식 수정

## Check List
- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 작업한 사람 모두를 Assign
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인
